### PR TITLE
Generically handle all exceptions in get_window()

### DIFF
--- a/brightml/xdisplay.py
+++ b/brightml/xdisplay.py
@@ -40,8 +40,7 @@ class Display():
             active_window = self.disp.create_resource_object('window', window_id)
             window_class = " ".join(active_window.get_wm_class())
             window_name = active_window.get_full_property(self.NET_WM_NAME, 0).value
-        except Xlib.error.XError:  # simplify dealing with BadWindow
-            #self.disp, self.root = self.get_display_and_root()
+        except:
             return None
         return Window(active_window, window_name, window_class)
 


### PR DESCRIPTION
ALL of the intermediate expressions or statements in `get_window()` have the potential to raise exceptions, none of which are interesting or should be handled any differently.

I figure it serves us better to simply catch all of them, return `None`, and shut up.

Resolves #10 